### PR TITLE
create configmaps instead of apply

### DIFF
--- a/tasks/create_configmap.yaml
+++ b/tasks/create_configmap.yaml
@@ -1,0 +1,23 @@
+- name: Find existing Configmap
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: "{{ item.metadata.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: existing_configmap
+
+- debug:
+    msg: "Creating Configmap {{ item.metadata.name }}, {{ item.kind }}"
+  when: existing_configmap.resources | length == 0
+
+- name: Create non existing ConfigMap
+  k8s:
+    resource_definition: "{{ item }}"
+    validate:
+      fail_on_error: true
+      strict: true
+  when: existing_configmap.resources | length == 0
+
+- debug:
+    msg: "Skip creation of existing ConfigMap {{ item.metadata.name }}, {{ item.kind }}"
+  when: existing_configmap.resources | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,23 +9,11 @@
 
 - name: Split objects into to be created and to be applied
   set_fact:
-    present_create_objects: "{{ present_objects | selectattr('kind', 'equalto', 'ConfigMap') | list }}"
+    present_create_configmaps: "{{ present_objects | selectattr('kind', 'equalto', 'ConfigMap') | list }}"
     present_apply_objects: "{{ present_objects | rejectattr('kind', 'equalto', 'ConfigMap') | list }}"
 
-- name: Log objects to create
-  debug:
-    msg: "Creating {{ item.metadata.name }}"
-  loop: "{{ present_create_objects }}"
-  loop_control:
-    label: "{{ item.metadata.name }}"
-
-- name: Create resources
-  k8s:
-    resource_definition: "{{ present_create_objects }}"
-    validate:
-      fail_on_error: true
-      strict: true
-  when: present_create_objects | length > 0
+- include_tasks: create_configmap.yml
+  loop: "{{ present_create_configmaps }}"
 
 - name: Log objects to apply
   debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,21 +7,41 @@
     absent_objects: "{{ objects | selectattr('state', 'defined') | selectattr('state', 'equalto', 'absent') | list |
                         map(attribute='object')| list }}"
 
-- name: Log objects to apply
+- name: Split objects into to be created and to be applied
+  set_fact:
+    present_create_objects: "{{ present_objects | selectattr('kind', 'equalto', 'ConfigMap') | list }}"
+    present_apply_objects: "{{ present_objects | rejectattr('kind', 'equalto', 'ConfigMap') | list }}"
+
+- name: Log objects to create
   debug:
-    msg: "Applying {{ item.metadata.name }}"
-  loop: "{{ present_objects }}"
+    msg: "Creating {{ item.metadata.name }}"
+  loop: "{{ present_create_objects }}"
   loop_control:
     label: "{{ item.metadata.name }}"
 
-- name: Apply objects
+- name: Create resources
   k8s:
-    apply: true
-    resource_definition: "{{ present_objects }}"
+    resource_definition: "{{ present_create_objects }}"
     validate:
       fail_on_error: true
       strict: true
-  when: present_objects | length > 0
+  when: present_create_objects | length > 0
+
+- name: Log objects to apply
+  debug:
+    msg: "Applying {{ item.metadata.name }}, {{ item.kind }}"
+  loop: "{{ present_apply_objects }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Apply other resources
+  k8s:
+    apply: true
+    resource_definition: "{{ present_apply_objects }}"
+    validate:
+      fail_on_error: true
+      strict: true
+  when: present_apply_objects | length > 0
 
 - name: Log objects to remove
   debug:


### PR DESCRIPTION
# Omschrijving

because of size limitations for Configmaps (1MB), ConfigMaps are no longer applied but instead created in the cluster. This way the last-applied annotation is left out of the Configmap

https://dev.kadaster.nl/jira/browse/PDOK-13468

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Verbetering oude feature

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [x] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [x] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [x] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [x] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)